### PR TITLE
fix network templates for debian based systems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,17 +27,23 @@ network_interfaces: []
 # .. code-block:: YAML
 #
 #   network_interfaces:
+#     # a normal interface with a static IPv4 and IPv6 address
 #     - device: eth0
 #       tmpl: ethernet
 #       hwaddress: 00:11:22:33:44:55
 #       force: True  # enforce that the configuration will be written
 #       ipv4:
-#         type: static
 #         addr: 192.0.2.10
 #         mask: 255.255.255.0
 #       ipv6:
-#         type: static
 #         addr: 2001:db8::10
 #         mask: 64
 #       ipv4_gateway: 192.0.2.1
 #       ipv6_gateway: 2001:db8::1
+#     # a interface which has no configuration at all
+#     - device: eth1
+#       tmpl: ethernet
+#     # a interface which will get the information from dhcp
+#     - device: eth1
+#       tmpl: ethernet
+#       ipv4_dhcp: True

--- a/templates/etc/Debian/ethernet.j2
+++ b/templates/etc/Debian/ethernet.j2
@@ -3,68 +3,66 @@
 auto {{ item.device }}
 allow-hotplug {{ item.device }}
 
-{% if item.ipv4 is defined %}
-iface {{ item.device }} inet {{ item.ipv4.type }}
-{% if item.ipv4.type == 'static' %}
+{% if item.ipv4_dhcp | default(False) %}
+iface {{ item.device }} inet dhcp
+{% elif item.ipv4 | default(False) %}
+iface {{ item.device }} inet static
     address     {{ item.ipv4.addr }}
-    netmask     {{ item.ipv4.mask | d("255.255.255.0") }}
-{% if item.ipv4_gateway is defined %}
+    netmask     {{ item.ipv4.mask | default("255.255.255.0") }}
+{% if item.ipv4_gateway | default(False) %}
     gateway     {{ item.ipv4_gateway }}
 {% endif %}
-{% endif %}
-{% if item.hwaddress | d(False) %}
+{% if item.hwaddress | default(False) %}
     hwaddress   {{ item.hwaddress }}
 {% endif %}
-{% if item.ipv4.pre_up | d() %}
+{% if item.ipv4.pre_up | default() %}
     pre-up      {{ item.ipv4.pre_up }}
 {% endif %}
-{% if item.ipv4.up | d() %}
+{% if item.ipv4.up | default() %}
     up          {{ item.ipv4.up }}
 {% endif %}
-{% if item.ipv4.post_up | d() %}
+{% if item.ipv4.post_up | default() %}
     post-up     {{ item.ipv4.post_up }}
 {% endif %}
-{% if item.ipv4.pre_down | d() %}
+{% if item.ipv4.pre_down | default() %}
     pre-down    {{ item.ipv4.pre_down }}
 {% endif %}
-{% if item.ipv4.down | d() %}
+{% if item.ipv4.down | default() %}
     down        {{ item.ipv4.down }}
 {% endif %}
-{% if item.ipv4.post_down | d() %}
+{% if item.ipv4.post_down | default() %}
     post-down   {{ item.ipv4.post_down }}
 {% endif %}
 {% else %}
 iface {{ item.device }} inet manual
 {% endif %}
 
-{% if item.ipv6 is defined %}
-iface {{ item.device }} inet6 {{ item.ipv6.type }}
-{% if item.ipv6.type == 'static' %}
+{% if item.ipv6 | default(False) %}
+iface {{ item.device }} inet6 static
     address     {{ item.ipv6.addr }}
-    netmask     {{ item.ipv6.mask | d("64") }}
-{% if item.ipv6_gateway is defined %}
+    netmask     {{ item.ipv6.mask | default("64") }}
+{% if item.ipv6_gateway | default(False) %}
     gateway     {{ item.ipv6_gateway }}
 {% endif %}
-{% endif %}
-{% if item.hwaddress | d(False) %}
+{% if item.hwaddress | default(False) %}
     hwaddress   {{ item.hwaddress }}
 {% endif %}
-{% if item.ipv6.pre_up | d() %}
+{% if item.ipv6.pre_up | default() %}
     pre-up      {{ item.ipv6.pre_up }}
 {% endif %}
-{% if item.ipv6.up | d() %}
+{% if item.ipv6.up | default() %}
     up          {{ item.ipv6.up }}
 {% endif %}
-{% if item.ipv6.post_up | d() %}
+{% if item.ipv6.post_up | default() %}
     post-up     {{ item.ipv6.post_up }}
 {% endif %}
-{% if item.ipv6.pre_down | d() %}
+{% if item.ipv6.pre_down | default() %}
     pre-down    {{ item.ipv6.pre_down }}
 {% endif %}
-{% if item.ipv6.down | d() %}
+{% if item.ipv6.down | default() %}
     down        {{ item.ipv6.down }}
 {% endif %}
-{% if item.ipv6.post_down | d() %}
+{% if item.ipv6.post_down | default() %}
     post-down   {{ item.ipv6.post_down }}
 {% endif %}
 {% else %}

--- a/templates/etc/RedHat/ipv6.j2
+++ b/templates/etc/RedHat/ipv6.j2
@@ -5,9 +5,7 @@ IPV6_AUTOCONF={{ item.ipv6_autoconf | default("yes") }}
 {% if item.ipv6 | default(False) -%}
 IPV6INIT=yes
 IPV6_AUTOCONF=no
-{% if item.ipv6.type == 'static' %}
 IPV6ADDR={{ item.ipv6.addr }}
-{% endif %}
 {% endif -%}
 IPV6FORWARDING={{ item.ipv6_forwarding | default("no") }}
 IPV6_FAILURE_FATAL=no


### PR DESCRIPTION
Fix debian templates and set the same values as on RedHat based systems, because that's the nicer standard.