### PR TITLE
EL7: vconfig removal, keep on EL6

### DIFF
--- a/vars/CentOS_6.yml
+++ b/vars/CentOS_6.yml
@@ -1,0 +1,32 @@
+---
+
+# network related packages
+network_packages:
+  - bridge-utils
+  - iproute
+  - vconfig
+
+# remove non rfc 1149 compatible software
+network_packages_removed:
+  - NetworkManager
+  - NetworkManager-libnm
+  - avahi-autoipd
+  - avahi
+
+# system control configuration file for IPv6 RA
+network_config_sysctl_ipv6_ra: /etc/sysctl.d/network_ipv6_ra.conf
+
+# system control configuration file for tcp timestamps
+network_config_sysctl_tcp_timestamps: /etc/sysctl.d/tcp_timestamps.conf
+
+# network main configuration
+network_cfg_main: /etc/sysconfig/network
+
+# netowrk configuration directory
+network_cfg_dir: /etc/sysconfig/network-scripts/
+
+# resolv.conf filename
+network_resolv_conf: /etc/resolv.conf
+
+# sysctl binary
+network_sysctl_bin: /sbin/sysctl

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,7 +4,6 @@
 network_packages:
   - bridge-utils
   - iproute
-  - vconfig
 
 # remove non rfc 1149 compatible software
 network_packages_removed:

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -1,0 +1,32 @@
+---
+
+# network related packages
+network_packages:
+  - bridge-utils
+  - iproute
+  - vconfig
+
+# remove non rfc 1149 compatible software
+network_packages_removed:
+  - NetworkManager
+  - NetworkManager-libnm
+  - avahi-autoipd
+  - avahi
+
+# system control configuration file for IPv6 RA
+network_config_sysctl_ipv6_ra: /etc/sysctl.d/network_ipv6_ra.conf
+
+# system control configuration file for tcp timestamps
+network_config_sysctl_tcp_timestamps: /etc/sysctl.d/tcp_timestamps.conf
+
+# network main configuration
+network_cfg_main: /etc/sysconfig/network
+
+# netowrk configuration directory
+network_cfg_dir: /etc/sysconfig/network-scripts/
+
+# resolv.conf filename
+network_resolv_conf: /etc/resolv.conf
+
+# sysctl binary
+network_sysctl_bin: /sbin/sysctl


### PR DESCRIPTION
##### SUMMARY

For generic EL distributions drop vconfig since it was dropped with EL7, for CentOS 6 and RHEL 6 keep vconfig which is still supported there.

For details see issue #4 

##### ISSUE TYPE

 - Bugfix Pull Request

##### ANSIBLE VERSION

```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [removed]
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION

* Expected behaviour before: EL6 based distributions work, but RHEL7 and CentOS 7 without EPEL fail.
* Expected behaviour afterwards: EL6 based distributions still work, but EL7 based distributions do work with the default set of repositories