### PR TITLE
templates: Add ansible_managed to EL distributions

### DIFF
--- a/templates/etc/RedHat/header.j2
+++ b/templates/etc/RedHat/header.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 TYPE={{ item.tmpl | capitalize }}
 DEVICE="{{ item.device }}"
 NAME="{{ item.device }}"


### PR DESCRIPTION
##### SUMMARY

Add ansible_managed to EL distributions templates  which was already present for Debian-based distributions but was missing here.

Resolves #5 , RH network configuration missing ansible_managed

##### ISSUE TYPE

 - Bugfix Pull Request

##### ANSIBLE VERSION

```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [removed]
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION

None required for what I can tell.