### PR TITLE
added IPV6_auto option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,7 @@ network_interfaces: []
 #     - device: eth1
 #       tmpl: ethernet
 #       ipv4_dhcp: True
+#     # a interface which configured automaticly
+#     - device: eth1
+#       tmpl: ethernet
+#       ipv6_auto: True

--- a/templates/etc/Debian/ethernet.j2
+++ b/templates/etc/Debian/ethernet.j2
@@ -41,6 +41,8 @@ iface {{ item.device }} inet manual
 iface {{ item.device }} inet6 static
     address     {{ item.ipv6.addr }}
     netmask     {{ item.ipv6.mask | default("64") }}
+{% elif item.ipv6_auto | default(False) %}
+iface {{ item.device }} inet6 auto
 {% if item.ipv6_gateway | default(False) %}
     gateway     {{ item.ipv6_gateway }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Implemented the function that IPV6 interfaces can be configured with auto

/etc/network/interface.d/ifcfg-eth1
```
iface ens3 inet6 auto
```

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
ansible 2.9.4
```


##### ADDITIONAL INFORMATION

